### PR TITLE
Feature: Add boolean autoincrement support to factories

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 Parley Company
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/lib/factory.js
+++ b/lib/factory.js
@@ -104,7 +104,7 @@ class Factory {
         let counter = attr.counter || 0;
         let increment = attr.auto_increment;
         if (increment) {
-          if (increment && typeof increment === 'boolean') {
+          if (typeof increment === 'boolean') {
             increment = 1;
           }
           counter += increment;
@@ -140,7 +140,7 @@ class Factory {
         let counter = attr.counter || 0;
         let increment = attr.auto_increment;
         if (increment) {
-          if (increment && typeof increment === 'boolean') {
+          if (typeof increment === 'boolean') {
             increment = 1;
           }
           counter += increment;

--- a/lib/factory.js
+++ b/lib/factory.js
@@ -102,11 +102,10 @@ class Factory {
       if (typeof attr === 'object') {
         let value = attr.value;
         let counter = attr.counter || 0;
-        let increment = attr.auto_increment;
+        let increment = (attr.auto_increment && 
+          typeof attr.auto_increment === 'boolean') ?
+          1 : attr.auto_increment;
         if (increment) {
-          if (typeof increment === 'boolean') {
-            increment = 1;
-          }
           counter += increment;
           if (typeof value === 'string') {
             value = value.replace('%d', counter);
@@ -138,11 +137,10 @@ class Factory {
 
       if (typeof attr === 'object' &&  this.attrs[key]) {
         let counter = attr.counter || 0;
-        let increment = attr.auto_increment;
+        let increment = (attr.auto_increment && 
+          typeof attr.auto_increment === 'boolean') ?
+          1 : attr.auto_increment;
         if (increment) {
-          if (typeof increment === 'boolean') {
-            increment = 1;
-          }
           counter += increment;
           this.attrs[key].counter = counter;
         }

--- a/lib/factory.js
+++ b/lib/factory.js
@@ -104,6 +104,9 @@ class Factory {
         let counter = attr.counter || 0;
         let increment = attr.auto_increment;
         if (increment) {
+          if (increment && typeof increment === 'boolean') {
+            increment = 1;
+          }
           counter += increment;
           if (typeof value === 'string') {
             value = value.replace('%d', counter);
@@ -137,6 +140,9 @@ class Factory {
         let counter = attr.counter || 0;
         let increment = attr.auto_increment;
         if (increment) {
+          if (increment && typeof increment === 'boolean') {
+            increment = 1;
+          }
           counter += increment;
           this.attrs[key].counter = counter;
         }
@@ -159,7 +165,10 @@ class Factory {
       };
     }
 
-    const increment = (!parent) ? this.attrs.id.auto_increment : 0;
+    let increment = (!parent) ? this.attrs.id.auto_increment : 0;
+    if (increment && typeof increment === 'boolean') {
+      increment = 1;
+    }
 
     // Update id value
     this.attrs.id.value = (query && query.id) ? query.id 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sails-factory-multitenant",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Simple model factory for Sails.js 1.X with multitenancy features. Based on sails-factory and inspired on Factory-Girl.",
   "main": "index.js",
   "scripts": {

--- a/test/unit/lib/sails-factory.test.js
+++ b/test/unit/lib/sails-factory.test.js
@@ -164,99 +164,198 @@ describe(TEST_NAME, function() {
     });
   });
 
-  describe('auto increment attributes', function() {
-    before(function() {
-      Self.define('sample2')
-        .attr('id', 0, { auto_increment: 1 })
-        .attr('title', 'title-%d', { auto_increment: 2 })
-        .attr('numero', function() {
-          return Math.random() * 100;
-        })
-        .attr('description', 'using sequence')
-        .parent('sample');
-    });
+  describe('Auto increment attributes', function() {
+    describe('With numeric auto increment', function() {
+      before(function() {
+        Self.define('sample2')
+          .attr('id', 0, { auto_increment: 1 })
+          .attr('title', 'title-%d', { auto_increment: 2 })
+          .attr('numero', function() {
+            return Math.random() * 100;
+          })
+          .attr('description', 'using sequence')
+          .parent('sample');
+      });
 
-    it('should be shared among children', function(done) {
-      let id;
-      async.series([
-        async function(done) {
-          await Self.create('sample2', function(sample) {
-            id = sample.id;
-            expect(sample).to.have.property('id', id++);
-            expect(sample).to.have.property('title', 'title-2');
-            expect(sample).to.have.property('numero');
-            expect(sample.numero).to.be.within(0,100);
-            done();
-          });
-        },
-        async function(done) {
-          await Self.create('sample', function(sample) {
-            expect(sample).to.have.property('id', id++);
-            expect(sample).to.have.property('foo', 'bar');
-            done();
-          });
-        },
-        async function(done) {
-          await Self.create('sample2', function(sample) {
-            expect(sample).to.have.property('id', id++);
-            expect(sample).to.have.property('title', 'title-4');
-            done();
-          });
-        },
-        function(done) {
-          Self.build('sample2', function(sample) {
-            expect(sample).to.have.property('id', id++);
-            expect(sample).to.have.property('title', 'title-6');
-            done();
-          });
-        },
-        function(done) {
-          Self.build('sample', function(sample) {
-            expect(sample).to.have.property('id', id++);
-            expect(sample).to.have.property('foo', 'bar');
-            done();
-          });
-        },
-        async function(done) {
-          await Self.create('sample2', function(sample) {
-            expect(sample).to.have.property('id', id++);
-            expect(sample).to.have.property('title', 'title-8');
-            done();
-          });
-        }
-      ], function(err) {
-        done(err);
+      it('should be shared among children', function(done) {
+        let id;
+        async.series([
+          async function(done) {
+            await Self.create('sample2', function(sample) {
+              id = sample.id;
+              expect(sample).to.have.property('id', id++);
+              expect(sample).to.have.property('title', 'title-2');
+              expect(sample).to.have.property('numero');
+              expect(sample.numero).to.be.within(0,100);
+              done();
+            });
+          },
+          async function(done) {
+            await Self.create('sample', function(sample) {
+              expect(sample).to.have.property('id', id++);
+              expect(sample).to.have.property('foo', 'bar');
+              done();
+            });
+          },
+          async function(done) {
+            await Self.create('sample2', function(sample) {
+              expect(sample).to.have.property('id', id++);
+              expect(sample).to.have.property('title', 'title-4');
+              done();
+            });
+          },
+          function(done) {
+            Self.build('sample2', function(sample) {
+              expect(sample).to.have.property('id', id++);
+              expect(sample).to.have.property('title', 'title-6');
+              done();
+            });
+          },
+          function(done) {
+            Self.build('sample', function(sample) {
+              expect(sample).to.have.property('id', id++);
+              expect(sample).to.have.property('foo', 'bar');
+              done();
+            });
+          },
+          async function(done) {
+            await Self.create('sample2', function(sample) {
+              expect(sample).to.have.property('id', id++);
+              expect(sample).to.have.property('title', 'title-8');
+              done();
+            });
+          }
+        ], function(err) {
+          done(err);
+        });
+      });
+
+      it('can be overridden', function(done) {
+        async.series([
+          function(done) {
+            Self.build('sample', {id: 99}, function(sample) {
+              expect(sample).to.have.property('id', 99);
+              done();
+            });
+          },
+          async function(done) {
+            await Self.create('sample', {id: 999}, function(sample) {
+              expect(sample).to.have.property('id', 999);
+              done();
+            });
+          },
+          async function(done) {
+            Self.build('sample2', {id: 88}, function(sample) {
+              expect(sample).to.have.property('id', 88);
+              done();
+            });
+          },
+          async function(done) {
+            await Self.create('sample2', {id: 888}, function(sample) {
+              expect(sample).to.have.property('id', 888);
+              done();
+            });
+          }
+        ], function(err) {
+          done(err);
+        });
       });
     });
 
-    it('can be overridden', function(done) {
-      async.series([
-        function(done) {
-          Self.build('sample', {id: 99}, function(sample) {
-            expect(sample).to.have.property('id', 99);
-            done();
-          });
-        },
-        async function(done) {
-          await Self.create('sample', {id: 999}, function(sample) {
-            expect(sample).to.have.property('id', 999);
-            done();
-          });
-        },
-        async function(done) {
-          Self.build('sample2', {id: 88}, function(sample) {
-            expect(sample).to.have.property('id', 88);
-            done();
-          });
-        },
-        async function(done) {
-          await Self.create('sample2', {id: 888}, function(sample) {
-            expect(sample).to.have.property('id', 888);
-            done();
-          });
-        }
-      ], function(err) {
-        done(err);
+    describe('With boolean auto increment', function() {
+      before(function() {
+        Self.define('sample2')
+          .attr('id', 0, { auto_increment: true })
+          .attr('title', 'title-%d', { auto_increment: true })
+          .attr('numero', function() {
+            return Math.random() * 100;
+          })
+          .attr('description', 'using sequence')
+          .parent('sample');
+        });
+      
+      it('Should be shared among children', function(done) {
+        let id;
+        async.series([
+          async function(done) {
+            await Self.create('sample2', function(sample) {
+              id = sample.id;
+              expect(sample).to.have.property('id', id++);
+              expect(sample).to.have.property('title', 'title-1');
+              expect(sample).to.have.property('numero');
+              expect(sample.numero).to.be.within(0,100);
+              done();
+            });
+          },
+          async function(done) {
+            await Self.create('sample', function(sample) {
+              expect(sample).to.have.property('id', id++);
+              expect(sample).to.have.property('foo', 'bar');
+              done();
+            });
+          },
+          async function(done) {
+            await Self.create('sample2', function(sample) {
+              expect(sample).to.have.property('id', id++);
+              expect(sample).to.have.property('title', 'title-2');
+              done();
+            });
+          },
+          function(done) {
+            Self.build('sample2', function(sample) {
+              expect(sample).to.have.property('id', id++);
+              expect(sample).to.have.property('title', 'title-3');
+              done();
+            });
+          },
+          function(done) {
+            Self.build('sample', function(sample) {
+              expect(sample).to.have.property('id', id++);
+              expect(sample).to.have.property('foo', 'bar');
+              done();
+            });
+          },
+          async function(done) {
+            await Self.create('sample2', function(sample) {
+              expect(sample).to.have.property('id', id++);
+              expect(sample).to.have.property('title', 'title-4');
+              done();
+            });
+          }
+        ], function(err) {
+          done(err);
+        });
+      });
+
+      it('can be overridden', function(done) {
+        async.series([
+          function(done) {
+            Self.build('sample', {id: 991}, function(sample) {
+              expect(sample).to.have.property('id', 991);
+              done();
+            });
+          },
+          async function(done) {
+            await Self.create('sample', {id: 9991}, function(sample) {
+              expect(sample).to.have.property('id', 9991);
+              done();
+            });
+          },
+          async function(done) {
+            Self.build('sample2', {id: 881}, function(sample) {
+              expect(sample).to.have.property('id', 881);
+              done();
+            });
+          },
+          async function(done) {
+            await Self.create('sample2', {id: 8881}, function(sample) {
+              expect(sample).to.have.property('id', 8881);
+              done();
+            });
+          }
+        ], function(err) {
+          done(err);
+        });
       });
     });
   });


### PR DESCRIPTION
## Features added
 
- Autoincrement now support boolean and numbers. If the property is set to boolean true, the property increment by 1 each interaction. If set to integer number, the property increment his value sum the number set by each interaction.
```js
factory.define("user")
    .attr("id", 0, { auto_increment: true })
    .attr("first_name", "First Name - ", { auto_increment: 5 });

// user:
// {
//    id: 1,
//    first_name: "First Name - 5",
//    ...
// }
```

- Add new test to approve this feature
- Add MIT License

## Test
To run validate feature follow next instructions:

### Precondition
```bash
npm install
````

### Testing
- Run test commands
```bash
npm test
```

### Expected
- The test process would pass all test without error